### PR TITLE
Avoid relying on state by splitting into 2 files

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,4 +11,4 @@ inputs:
 runs:
   using: 'node12'
   main: 'main.js'
-  post: 'main.js'
+  post: 'post.js'

--- a/post.js
+++ b/post.js
@@ -8,19 +8,19 @@ const execAsync = promisify(exec);
 const builder = core.getInput('builder');
 const path = core.getInput('cache-path');
 
-async function run() {
+async function post() {
   try {
-    await execAsync('docker buildx stop');
+    await execAsync(`docker buildx prune --force --keep-storage ${ core.getInput('cache-max-size')}`)
 
     await execAsync(`docker run --rm \
       --volumes-from ${ builder } \
       -v ${ path }:/cache \
-      alpine /bin/sh -c "cd / && tar xf /cache/buildkit-state.tar"`);
+      alpine /bin/sh -c "cd / && tar cf /cache/buildkit-state.tar /var/lib/buildkit"`);
 
-    core.info('Cache restored successfully');
+    core.info('Cache archived successfully');
   } catch (error) {
-    core.error(`Cache restore failed: ${ error }`)
+    core.error(`Cache archive failed: ${ error }`);
   }
 }
 
-run()
+post()


### PR DESCRIPTION
I tried out this action but I couldn't get it to run successfully the first time, because the `main` step resulted in an error and therefore when Github Actions tried to run the `post` step, it actually ended up running `main` again (I think because the state didn't get set correctly).  To fix this, I tried splitting the main.js file into separate files and referencing them separately in the action.yml, which seeemed to fix the issue for me.