### PR TITLE
feat: More targeted pruning

### DIFF
--- a/main.js
+++ b/main.js
@@ -19,6 +19,7 @@ async function run() {
 
     core.info('Cache restored successfully');
 
+    await execAsync('docker buildx start');
     var {stdout, stderr} = await execAsync(`docker buildx du --verbose`);
     core.info(`Cache now contains:\n${stdout}\n`);
   } catch (error) {

--- a/main.js
+++ b/main.js
@@ -19,7 +19,7 @@ async function run() {
 
     core.info('Cache restored successfully');
 
-    var {stdout, stderr} = await execAsync(`docker buildx du -v`);
+    var {stdout, stderr} = await execAsync(`docker buildx du --verbose`);
     core.info(`Cache now contains:\n${stdout}\n`);
   } catch (error) {
     core.error(`Cache restore failed: ${ error }`);

--- a/main.js
+++ b/main.js
@@ -19,7 +19,7 @@ async function run() {
 
     core.info('Cache restored successfully');
 
-    await execAsync('docker buildx start');
+    await execAsync('docker buildx inspect --bootstrap');
     var {stdout, stderr} = await execAsync(`docker buildx du --verbose`);
     core.info(`Cache now contains:\n${stdout}\n`);
   } catch (error) {

--- a/main.js
+++ b/main.js
@@ -18,8 +18,11 @@ async function run() {
       alpine /bin/sh -c "cd / && tar xf /cache/buildkit-state.tar"`);
 
     core.info('Cache restored successfully');
+
+    var {stdout, stderr} = await execAsync(`docker exec ${builder} buildctl du -v`);
+    core.info(`Cache now contains:\n${stdout}\n`);
   } catch (error) {
-    core.error(`Cache restore failed: ${ error }`)
+    core.error(`Cache restore failed: ${ error }`);
   }
 }
 

--- a/main.js
+++ b/main.js
@@ -19,6 +19,8 @@ async function run() {
 
     core.info('Cache restored successfully');
 
+    await execAsync('docker buildx start');
+
     var {stdout, stderr} = await execAsync(`docker exec ${builder} buildctl du -v`);
     core.info(`Cache now contains:\n${stdout}\n`);
   } catch (error) {

--- a/main.js
+++ b/main.js
@@ -19,9 +19,7 @@ async function run() {
 
     core.info('Cache restored successfully');
 
-    await execAsync('docker buildx start');
-
-    var {stdout, stderr} = await execAsync(`docker exec ${builder} buildctl du -v`);
+    var {stdout, stderr} = await execAsync(`docker buildx du -v`);
     core.info(`Cache now contains:\n${stdout}\n`);
   } catch (error) {
     core.error(`Cache restore failed: ${ error }`);

--- a/post.js
+++ b/post.js
@@ -13,44 +13,44 @@ async function post() {
     core.info("Before pruning:");
     var {stdout, stderr} = await execAsync(`docker exec ${builder} buildctl du`);
     core.info(`stdout:\n${stdout}\n`);
-    if (error) { core.error(`stderr:\n${stderr}\n`); }
+    if (stderr) { core.error(`stderr:\n${stderr}\n`); }
 
     var {stdout, stderr} = await execAsync(`docker buildx prune --force --filter type=regular`);
     core.info(`stdout:\n${stdout}\n`);
-    if (error) { core.error(`stderr:\n${stderr}\n`); }
+    if (stderr) { core.error(`stderr:\n${stderr}\n`); }
 
     var {stdout, stderr} = await execAsync(`docker buildx prune --force --filter type=source.local`);
     core.info(`stdout:\n${stdout}\n`);
-    if (error) { core.error(`stderr:\n${stderr}\n`); }
+    if (stderr) { core.error(`stderr:\n${stderr}\n`); }
 
     var {stdout, stderr} = await execAsync(`docker buildx prune --force --filter type=frontend`);
     core.info(`stdout:\n${stdout}\n`);
-    if (error) { core.error(`stderr:\n${stderr}\n`); }
+    if (stderr) { core.error(`stderr:\n${stderr}\n`); }
 
     var {stdout, stderr} = await execAsync(`docker buildx prune --force --filter type=internal`);
     core.info(`stdout:\n${stdout}\n`);
-    if (error) { core.error(`stderr:\n${stderr}\n`); }
+    if (stderr) { core.error(`stderr:\n${stderr}\n`); }
 
     var {stdout, stderr} = await execAsync(`docker buildx prune --force --filter type=exec.cachemount --keep-storage ${core.getInput('cache-max-size')}`);
     core.info(`stdout:\n${stdout}\n`);
-    if (error) { core.error(`stderr:\n${stderr}\n`); }
+    if (stderr) { core.error(`stderr:\n${stderr}\n`); }
 
     core.info("After pruning:");
 
     var {stdout, stderr} = await execAsync(`docker exec ${builder} buildctl du`);
     core.info(`stdout:\n${stdout}\n`);
-    if (error) { core.error(`stderr:\n${stderr}\n`); }
+    if (stderr) { core.error(`stderr:\n${stderr}\n`); }
 
     var {stdout, stderr} = await execAsync(`docker exec ${builder} buildctl du -v`);
     core.info(`stdout:\n${stdout}\n`);
-    if (error) { core.error(`stderr:\n${stderr}\n`); }
+    if (stderr) { core.error(`stderr:\n${stderr}\n`); }
 
     var {stdout, stderr} = await execAsync(`docker run --rm \
       --volumes-from ${builder} \
       -v ${path}:/cache \
       alpine /bin/sh -c "cd / && tar cf /cache/buildkit-state.tar var/lib/buildkit"`);
     core.info(`stdout:\n${stdout}\n`);
-    if (error) { core.error(`stderr:\n${stderr}\n`); }
+    if (stderr) { core.error(`stderr:\n${stderr}\n`); }
 
     core.info("Cache archived successfully");
   } catch (error) {

--- a/post.js
+++ b/post.js
@@ -12,33 +12,45 @@ async function post() {
   try {
     core.info("Before pruning:");
     var {stdout, stderr} = await execAsync(`docker exec ${builder} buildctl du`);
-    core.info(`stdout: ${stdout}`);
-    core.error(`stderr: ${stderr}`);
-
-    var {stdout, stderr} = await execAsync(`docker exec ${builder} buildctl du -v`);
-    core.info(`stdout: ${stdout}`);
-    core.error(`stderr: ${stderr}`);
+    core.info(`stdout:\n${stdout}\n`);
+    if (error) { core.error(`stderr:\n${stderr}\n`); }
 
     var {stdout, stderr} = await execAsync(`docker buildx prune --force --filter type=regular`);
-    core.info(`stdout: ${stdout}`);
-    core.error(`stderr: ${stderr}`);
+    core.info(`stdout:\n${stdout}\n`);
+    if (error) { core.error(`stderr:\n${stderr}\n`); }
+
+    var {stdout, stderr} = await execAsync(`docker buildx prune --force --filter type=source.local`);
+    core.info(`stdout:\n${stdout}\n`);
+    if (error) { core.error(`stderr:\n${stderr}\n`); }
+
+    var {stdout, stderr} = await execAsync(`docker buildx prune --force --filter type=frontend`);
+    core.info(`stdout:\n${stdout}\n`);
+    if (error) { core.error(`stderr:\n${stderr}\n`); }
+
+    var {stdout, stderr} = await execAsync(`docker buildx prune --force --filter type=internal`);
+    core.info(`stdout:\n${stdout}\n`);
+    if (error) { core.error(`stderr:\n${stderr}\n`); }
+
+    var {stdout, stderr} = await execAsync(`docker buildx prune --force --filter type=exec.cachemount --keep-storage ${core.getInput('cache-max-size')}`);
+    core.info(`stdout:\n${stdout}\n`);
+    if (error) { core.error(`stderr:\n${stderr}\n`); }
 
     core.info("After pruning:");
 
     var {stdout, stderr} = await execAsync(`docker exec ${builder} buildctl du`);
-    core.info(`stdout: ${stdout}`);
-    core.error(`stderr: ${stderr}`);
+    core.info(`stdout:\n${stdout}\n`);
+    if (error) { core.error(`stderr:\n${stderr}\n`); }
 
     var {stdout, stderr} = await execAsync(`docker exec ${builder} buildctl du -v`);
-    core.info(`stdout: ${stdout}`);
-    core.error(`stderr: ${stderr}`);
+    core.info(`stdout:\n${stdout}\n`);
+    if (error) { core.error(`stderr:\n${stderr}\n`); }
 
     var {stdout, stderr} = await execAsync(`docker run --rm \
       --volumes-from ${builder} \
       -v ${path}:/cache \
       alpine /bin/sh -c "cd / && tar cf /cache/buildkit-state.tar var/lib/buildkit"`);
-    core.info(`stdout: ${stdout}`);
-    core.error(`stderr: ${stderr}`);
+    core.info(`stdout:\n${stdout}\n`);
+    if (error) { core.error(`stderr:\n${stderr}\n`); }
 
     core.info("Cache archived successfully");
   } catch (error) {

--- a/post.js
+++ b/post.js
@@ -41,7 +41,7 @@ async function post() {
     core.info(`stdout:\n${stdout}\n`);
     if (stderr) { core.error(`stderr:\n${stderr}\n`); }
 
-    var {stdout, stderr} = await execAsync(`docker buildx du -v`);
+    var {stdout, stderr} = await execAsync(`docker buildx du --verbose`);
     core.info(`stdout:\n${stdout}\n`);
     if (stderr) { core.error(`stderr:\n${stderr}\n`); }
 

--- a/post.js
+++ b/post.js
@@ -10,6 +10,7 @@ const path = core.getInput('cache-path');
 
 async function post() {
   try {
+    console.log("step1")
     await execAsync(`docker system df -v`, {}, function(error,stdout,stderr) {
       if (error) {
         console.error(`exec error: ${error}`)
@@ -18,7 +19,7 @@ async function post() {
       console.log(`stdout: ${stdout}`)
       console.error(`stderr: ${stderr}`)
     })
-
+    console.log("step2")
     await execAsync(`docker buildx du -v`, {}, function(error,stdout,stderr) {
       if (error) {
         console.error(`exec error: ${error}`)
@@ -27,7 +28,7 @@ async function post() {
       console.log(`stdout: ${stdout}`)
       console.error(`stderr: ${stderr}`)
     })
-
+    console.log("step3")
     await execAsync(`docker exec ${ builder } buildctl du -v`, {}, function(error,stdout,stderr) {
       if (error) {
         console.error(`exec error: ${error}`)
@@ -36,11 +37,9 @@ async function post() {
       console.log(`stdout: ${stdout}`)
       console.error(`stderr: ${stderr}`)
     })
-
+    console.log("step4")
     await execAsync(`docker buildx prune --force --keep-storage ${ core.getInput('cache-max-size')}`)
-
-
-
+    console.log("step5")
     await execAsync(`docker run --rm \
       --volumes-from ${ builder } \
       -v ${ path }:/cache \

--- a/post.js
+++ b/post.js
@@ -10,36 +10,36 @@ const path = core.getInput('cache-path');
 
 async function post() {
   try {
-    console.log("step1")
+    core.info("step1")
     await execAsync(`docker system df -v`, {}, function(error,stdout,stderr) {
       if (error) {
-        console.error(`exec error: ${error}`)
+        core.error(`exec error: ${error}`)
         return
       }
-      console.log(`stdout: ${stdout}`)
-      console.error(`stderr: ${stderr}`)
+      core.info(`stdout: ${stdout}`)
+      core.error(`stderr: ${stderr}`)
     })
-    console.log("step2")
+    core.info("step2")
     await execAsync(`docker buildx du -v`, {}, function(error,stdout,stderr) {
       if (error) {
-        console.error(`exec error: ${error}`)
+        core.error(`exec error: ${error}`)
         return
       }
-      console.log(`stdout: ${stdout}`)
-      console.error(`stderr: ${stderr}`)
+      core.info(`stdout: ${stdout}`)
+      core.error(`stderr: ${stderr}`)
     })
-    console.log("step3")
+    core.info("step3")
     await execAsync(`docker exec ${ builder } buildctl du -v`, {}, function(error,stdout,stderr) {
       if (error) {
-        console.error(`exec error: ${error}`)
+        core.error(`exec error: ${error}`)
         return
       }
-      console.log(`stdout: ${stdout}`)
-      console.error(`stderr: ${stderr}`)
+      core.info(`stdout: ${stdout}`)
+      core.error(`stderr: ${stderr}`)
     })
-    console.log("step4")
+    core.info("step4")
     await execAsync(`docker buildx prune --force --keep-storage ${ core.getInput('cache-max-size')}`)
-    console.log("step5")
+    core.info("step5")
     await execAsync(`docker run --rm \
       --volumes-from ${ builder } \
       -v ${ path }:/cache \

--- a/post.js
+++ b/post.js
@@ -19,7 +19,7 @@ async function post() {
     core.info(`stdout: ${stdout}`);
     core.error(`stderr: ${stderr}`);
 
-    var {stdout, stderr} = await execAsync(`docker buildx prune --force --keep-storage ${core.getInput("cache-max-size")}`);
+    var {stdout, stderr} = await execAsync(`docker buildx prune --force --filter type=regular`);
     core.info(`stdout: ${stdout}`);
     core.error(`stderr: ${stderr}`);
 

--- a/post.js
+++ b/post.js
@@ -10,7 +10,18 @@ const path = core.getInput('cache-path');
 
 async function post() {
   try {
+    await execAsync(`docker system df -v`, {}, function(error,stdout,stderr) {
+      if (error) {
+        console.error(`exec error: ${error}`)
+        return
+      }
+      console.log(`stdout: ${stdout}`)
+      console.error(`stderr: ${stderr}`)
+    })
+
     await execAsync(`docker buildx prune --force --keep-storage ${ core.getInput('cache-max-size')}`)
+
+
 
     await execAsync(`docker run --rm \
       --volumes-from ${ builder } \

--- a/post.js
+++ b/post.js
@@ -11,82 +11,35 @@ const path = core.getInput("cache-path");
 async function post() {
   try {
     core.info("Before pruning:");
-    await execAsync(
-      `docker exec ${builder} buildctl du`,
-      {},
-      function (error, stdout, stderr) {
-        if (error) {
-          core.error(`exec error: ${error}`);
-          return;
-        }
-        core.info(`stdout: ${stdout}`);
-        core.error(`stderr: ${stderr}`);
-      }
-    );
-    await execAsync(
-      `docker exec ${builder} buildctl du -v`,
-      {},
-      function (error, stdout, stderr) {
-        if (error) {
-          core.error(`exec error: ${error}`);
-          return;
-        }
-        core.info(`stdout: ${stdout}`);
-        core.error(`stderr: ${stderr}`);
-      }
-    );
-    await execAsync(
-      `docker buildx prune --force --keep-storage ${core.getInput("cache-max-size")}`,
-      {},
-      function (error, stdout, stderr) {
-        if (error) {
-          core.error(`exec error: ${error}`);
-          return;
-        }
-        core.info(`stdout: ${stdout}`);
-        core.error(`stderr: ${stderr}`);
-      }
-    );
+    var {stdout, stderr} = await execAsync(`docker exec ${builder} buildctl du`);
+    core.info(`stdout: ${stdout}`);
+    core.error(`stderr: ${stderr}`);
+
+    var {stdout, stderr} = await execAsync(`docker exec ${builder} buildctl du -v`);
+    core.info(`stdout: ${stdout}`);
+    core.error(`stderr: ${stderr}`);
+
+    var {stdout, stderr} = await execAsync(`docker buildx prune --force --keep-storage ${core.getInput("cache-max-size")}`);
+    core.info(`stdout: ${stdout}`);
+    core.error(`stderr: ${stderr}`);
+
     core.info("After pruning:");
-    await execAsync(
-      `docker exec ${builder} buildctl du`,
-      {},
-      function (error, stdout, stderr) {
-        if (error) {
-          core.error(`exec error: ${error}`);
-          return;
-        }
-        core.info(`stdout: ${stdout}`);
-        core.error(`stderr: ${stderr}`);
-      }
-    );
-    await execAsync(
-      `docker exec ${builder} buildctl du -v`,
-      {},
-      function (error, stdout, stderr) {
-        if (error) {
-          core.error(`exec error: ${error}`);
-          return;
-        }
-        core.info(`stdout: ${stdout}`);
-        core.error(`stderr: ${stderr}`);
-      }
-    );
-    await execAsync(
-      `docker run --rm \
-        --volumes-from ${builder} \
-        -v ${path}:/cache \
-        alpine /bin/sh -c "cd / && tar cf /cache/buildkit-state.tar /var/lib/buildkit"`,
-      {},
-      function (error, stdout, stderr) {
-        if (error) {
-          core.error(`exec error: ${error}`);
-          return;
-        }
-        core.info(`stdout: ${stdout}`);
-        core.error(`stderr: ${stderr}`);
-      }
-    );
+
+    var {stdout, stderr} = await execAsync(`docker exec ${builder} buildctl du`);
+    core.info(`stdout: ${stdout}`);
+    core.error(`stderr: ${stderr}`);
+
+    var {stdout, stderr} = await execAsync(`docker exec ${builder} buildctl du -v`);
+    core.info(`stdout: ${stdout}`);
+    core.error(`stderr: ${stderr}`);
+
+    var {stdout, stderr} = await execAsync(`docker run --rm \
+      --volumes-from ${builder} \
+      -v ${path}:/cache \
+      alpine /bin/sh -c "cd / && tar cf /cache/buildkit-state.tar /var/lib/buildkit"`);
+    core.info(`stdout: ${stdout}`);
+    core.error(`stderr: ${stderr}`);
+
     core.info("Cache archived successfully");
   } catch (error) {
     core.error(`Cache archive failed: ${error}`);

--- a/post.js
+++ b/post.js
@@ -1,54 +1,96 @@
-const core = require('@actions/core');
+const core = require("@actions/core");
 
-const { exec } = require('child_process');
-const { promisify } = require('util');
+const { exec } = require("child_process");
+const { promisify } = require("util");
 
 const execAsync = promisify(exec);
 
-const builder = core.getInput('builder');
-const path = core.getInput('cache-path');
+const builder = core.getInput("builder");
+const path = core.getInput("cache-path");
 
 async function post() {
   try {
-    core.info("step1")
-    await execAsync(`docker system df -v`, {}, function(error,stdout,stderr) {
-      if (error) {
-        core.error(`exec error: ${error}`)
-        return
+    core.info("Before pruning:");
+    await execAsync(
+      `docker exec ${builder} buildctl du`,
+      {},
+      function (error, stdout, stderr) {
+        if (error) {
+          core.error(`exec error: ${error}`);
+          return;
+        }
+        core.info(`stdout: ${stdout}`);
+        core.error(`stderr: ${stderr}`);
       }
-      core.info(`stdout: ${stdout}`)
-      core.error(`stderr: ${stderr}`)
-    })
-    core.info("step2")
-    await execAsync(`docker buildx du --verbose`, {}, function(error,stdout,stderr) {
-      if (error) {
-        core.error(`exec error: ${error}`)
-        return
+    );
+    await execAsync(
+      `docker exec ${builder} buildctl du -v`,
+      {},
+      function (error, stdout, stderr) {
+        if (error) {
+          core.error(`exec error: ${error}`);
+          return;
+        }
+        core.info(`stdout: ${stdout}`);
+        core.error(`stderr: ${stderr}`);
       }
-      core.info(`stdout: ${stdout}`)
-      core.error(`stderr: ${stderr}`)
-    })
-    core.info("step3")
-    await execAsync(`docker exec ${ builder } buildctl du -v`, {}, function(error,stdout,stderr) {
-      if (error) {
-        core.error(`exec error: ${error}`)
-        return
+    );
+    await execAsync(
+      `docker buildx prune --force --keep-storage ${core.getInput("cache-max-size")}`,
+      {},
+      function (error, stdout, stderr) {
+        if (error) {
+          core.error(`exec error: ${error}`);
+          return;
+        }
+        core.info(`stdout: ${stdout}`);
+        core.error(`stderr: ${stderr}`);
       }
-      core.info(`stdout: ${stdout}`)
-      core.error(`stderr: ${stderr}`)
-    })
-    core.info("step4")
-    await execAsync(`docker buildx prune --force --keep-storage ${ core.getInput('cache-max-size')}`)
-    core.info("step5")
-    await execAsync(`docker run --rm \
-      --volumes-from ${ builder } \
-      -v ${ path }:/cache \
-      alpine /bin/sh -c "cd / && tar cf /cache/buildkit-state.tar /var/lib/buildkit"`);
-
-    core.info('Cache archived successfully');
+    );
+    core.info("After pruning:");
+    await execAsync(
+      `docker exec ${builder} buildctl du`,
+      {},
+      function (error, stdout, stderr) {
+        if (error) {
+          core.error(`exec error: ${error}`);
+          return;
+        }
+        core.info(`stdout: ${stdout}`);
+        core.error(`stderr: ${stderr}`);
+      }
+    );
+    await execAsync(
+      `docker exec ${builder} buildctl du -v`,
+      {},
+      function (error, stdout, stderr) {
+        if (error) {
+          core.error(`exec error: ${error}`);
+          return;
+        }
+        core.info(`stdout: ${stdout}`);
+        core.error(`stderr: ${stderr}`);
+      }
+    );
+    await execAsync(
+      `docker run --rm \
+        --volumes-from ${builder} \
+        -v ${path}:/cache \
+        alpine /bin/sh -c "cd / && tar cf /cache/buildkit-state.tar /var/lib/buildkit"`,
+      {},
+      function (error, stdout, stderr) {
+        if (error) {
+          core.error(`exec error: ${error}`);
+          return;
+        }
+        core.info(`stdout: ${stdout}`);
+        core.error(`stderr: ${stderr}`);
+      }
+    );
+    core.info("Cache archived successfully");
   } catch (error) {
-    core.error(`Cache archive failed: ${ error }`);
+    core.error(`Cache archive failed: ${error}`);
   }
 }
 
-post()
+post();

--- a/post.js
+++ b/post.js
@@ -36,7 +36,7 @@ async function post() {
     var {stdout, stderr} = await execAsync(`docker run --rm \
       --volumes-from ${builder} \
       -v ${path}:/cache \
-      alpine /bin/sh -c "cd / && tar cf /cache/buildkit-state.tar /var/lib/buildkit"`);
+      alpine /bin/sh -c "cd / && tar cf /cache/buildkit-state.tar var/lib/buildkit"`);
     core.info(`stdout: ${stdout}`);
     core.error(`stderr: ${stderr}`);
 

--- a/post.js
+++ b/post.js
@@ -19,6 +19,24 @@ async function post() {
       console.error(`stderr: ${stderr}`)
     })
 
+    await execAsync(`docker buildx du -v`, {}, function(error,stdout,stderr) {
+      if (error) {
+        console.error(`exec error: ${error}`)
+        return
+      }
+      console.log(`stdout: ${stdout}`)
+      console.error(`stderr: ${stderr}`)
+    })
+
+    await execAsync(`docker exec ${ builder } buildctl du -v`, {}, function(error,stdout,stderr) {
+      if (error) {
+        console.error(`exec error: ${error}`)
+        return
+      }
+      console.log(`stdout: ${stdout}`)
+      console.error(`stderr: ${stderr}`)
+    })
+
     await execAsync(`docker buildx prune --force --keep-storage ${ core.getInput('cache-max-size')}`)
 
 

--- a/post.js
+++ b/post.js
@@ -20,7 +20,7 @@ async function post() {
       core.error(`stderr: ${stderr}`)
     })
     core.info("step2")
-    await execAsync(`docker buildx du -v`, {}, function(error,stdout,stderr) {
+    await execAsync(`docker buildx du --verbose`, {}, function(error,stdout,stderr) {
       if (error) {
         core.error(`exec error: ${error}`)
         return

--- a/post.js
+++ b/post.js
@@ -11,7 +11,7 @@ const path = core.getInput("cache-path");
 async function post() {
   try {
     core.info("Before pruning:");
-    var {stdout, stderr} = await execAsync(`docker exec ${builder} buildctl du`);
+    var {stdout, stderr} = await execAsync(`docker buildx du`);
     core.info(`stdout:\n${stdout}\n`);
     if (stderr) { core.error(`stderr:\n${stderr}\n`); }
 
@@ -37,11 +37,11 @@ async function post() {
 
     core.info("After pruning:");
 
-    var {stdout, stderr} = await execAsync(`docker exec ${builder} buildctl du`);
+    var {stdout, stderr} = await execAsync(`docker buildx du`);
     core.info(`stdout:\n${stdout}\n`);
     if (stderr) { core.error(`stderr:\n${stderr}\n`); }
 
-    var {stdout, stderr} = await execAsync(`docker exec ${builder} buildctl du -v`);
+    var {stdout, stderr} = await execAsync(`docker buildx du -v`);
     core.info(`stdout:\n${stdout}\n`);
     if (stderr) { core.error(`stderr:\n${stderr}\n`); }
 


### PR DESCRIPTION
I've made some adjustments to more strategically target the pruning behavior: since the intent of this action is (I believe) to be able to "export" cache mounts (after all, it's already possible to export the layer cache using other mechanisms), I figure it would be worth specifically pruning away all cache types other than `exec.cachemount` before pruning for size. This reduces the amount of unnecessary data retained, and reduces the likelihood that we accidentally evict the cache mounts while retaining layers.

I also added some logging/diagnostic output, and ran the code through `prettier`, but, I can revert those parts if you like.