### PR TITLE
Switch to `node16`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,14 +1,14 @@
-name: 'Load buildkit state from cache'
-description: 'Copies state from cache into specified buildkit builder'
+name: "Load buildkit state from cache"
+description: "Copies state from cache into specified buildkit builder"
 inputs:
   builder:
-    description: 'buildkit builder to use'
+    description: "buildkit builder to use"
   cache-path:
-    description: 'path to restored cache file'
+    description: "path to restored cache file"
   cache-max-size:
-    description: 'maximum cache size'
+    description: "maximum cache size"
 
 runs:
-  using: 'node12'
-  main: 'main.js'
-  post: 'post.js'
+  using: "node16"
+  main: "main.js"
+  post: "post.js"


### PR DESCRIPTION
As per this warning in GitHub Actions, `node12` is deprecated.  Update to `node16`.

<img width="2032" alt="image" src="https://user-images.githubusercontent.com/40248929/208510637-66bff697-7394-4fdc-942f-db796e612392.png">