### PR TITLE
chore: exclude `sockets` from `tar` execution

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@strophy/gh-action-cache-buildkit-state",
-  "version": "1.0.0",
+  "version": "1.0.4",
   "description": "",
   "scripts": {
     "lint": "eslint ."

--- a/post.js
+++ b/post.js
@@ -48,7 +48,9 @@ async function post() {
     var {stdout, stderr} = await execAsync(`docker run --rm \
       --volumes-from ${builder} \
       -v ${path}:/cache \
-      alpine /bin/sh -c "cd / && tar cf /cache/buildkit-state.tar var/lib/buildkit"`);
+      alpine /bin/sh -c "cd / && \
+      find / -type s -print > /tmp/sockets-to-exclude && \
+      tar cf /cache/buildkit-state.tar -X /tmp/sockets-to-exclude var/lib/buildkit"`);
     core.info(`stdout:\n${stdout}\n`);
     if (stderr) { core.error(`stderr:\n${stderr}\n`); }
 

--- a/post.js
+++ b/post.js
@@ -49,7 +49,8 @@ async function post() {
       --volumes-from ${builder} \
       -v ${path}:/cache \
       alpine /bin/sh -c "cd / && \
-      find / -type s -print > /tmp/sockets-to-exclude && \
+      find var/lib/buildkit -type s -print > /tmp/sockets-to-exclude && \
+      cat /tmp/sockets-to-exclude && \
       tar cf /cache/buildkit-state.tar -X /tmp/sockets-to-exclude var/lib/buildkit"`);
     core.info(`stdout:\n${stdout}\n`);
     if (stderr) { core.error(`stderr:\n${stderr}\n`); }


### PR DESCRIPTION
Started to get this error when using this Action:

<img width="492" alt="image" src="https://user-images.githubusercontent.com/40248929/211665508-9576b113-646b-4cd2-8f06-92f73d474813.png">

<img width="447" alt="image" src="https://user-images.githubusercontent.com/40248929/211665541-ea525190-6752-4dde-9323-931f9eadea30.png">

Traced it to [here](https://github.com/dashevo/gh-action-cache-buildkit-state/blob/master/post.js#L51)
Appears related to [this](https://serverfault.com/questions/525805/getting-errors-while-making-backup-of-whole-centos-with-tar) and the `stderr` from `tar` can be removed by excluding the sockets from the tarball.

This PR does just that